### PR TITLE
Update Dockerfile to use default app user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG FINAL_BASE_IMAGE=${LAUNCHING_FROM_VS:+aotdebug}
 
 # Этот этап используется при запуске из VS в быстром режиме (по умолчанию для конфигурации отладки)
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-USER $APP_UID
+USER app
 WORKDIR /app
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- set default user to `app` instead of reading from `APP_UID`

## Testing
- `docker build -t test-image .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684654ad4cc88331a71ee93c7fae5cf6