### PR TITLE
Add CLI configuration comments

### DIFF
--- a/src/Migrator.Cli/Program.cs
+++ b/src/Migrator.Cli/Program.cs
@@ -2,23 +2,27 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using Migrator.Cli.Commands;
 
+// Создаём CLI-приложение с двумя ветками команд: create и migrate
 var app = new CommandApp();
 
 app.Configure(cfg =>
 {
     cfg.SetApplicationName("oracle2ch");
+    // Внутри регистрируются подкоманды «create» и «migrate»
     cfg.AddBranch("create", b =>
     {
         b.AddCommand<CreateAllCommand>("all");
         b.AddCommand<CreateTablesCommand>("tables");
     });
 
+    // Внутри регистрируются подкоманды «create» и «migrate»
     cfg.AddBranch("migrate", b =>
     {
         b.AddCommand<MigrateAllCommand>("all");
         b.AddCommand<MigrateTablesCommand>("tables");
     });
 
+    // PropagateExceptions позволяет увидеть исходное исключение при ошибке
     cfg.PropagateExceptions();
 });
 


### PR DESCRIPTION
## Summary
- add comment at top of `Program.cs` describing the CLI app
- explain the two branches before each `AddBranch` call
- note why `cfg.PropagateExceptions()` is used

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846592544ac833199988f33472edadf